### PR TITLE
Add redirect to BBB hack

### DIFF
--- a/bbb.html
+++ b/bbb.html
@@ -1,0 +1,3 @@
+<head> 
+  <meta http-equiv="refresh" content="0; URL=http://wired.org.au/bit-by-bit-hackathon-2019/" />
+</head>


### PR DESCRIPTION
This provides a short link to the BBB hack page, nobody wants to type the entire url (wired.org.au/bit-by-bit-hackathon-2019/)

CC @lorderikir 